### PR TITLE
Use signed-by instead of deprecated apt-key

### DIFF
--- a/docker/ubuntu-docker
+++ b/docker/ubuntu-docker
@@ -1,10 +1,9 @@
-FROM  ubuntu
-RUN apt-get update
-RUN apt-get install -y apt-transport-https ca-certificates curl
-RUN apt-get install -y gnupg
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
-RUN apt-get install -y kubectl
-RUN apt update
-RUN apt install python3  -y
+FROM ubuntu
+RUN apt update && apt install -y apt-transport-https ca-certificates curl gnupg  python3
+
+# Add google cloud GPG key and Kubernetes repository
+RUN mkdir -p /etc/apt/keyrings/
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /etc/apt/keyrings/google-cloud.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+
+RUN apt update && apt install -y kubectl

--- a/docker/ubuntu-docker
+++ b/docker/ubuntu-docker
@@ -2,8 +2,8 @@ FROM ubuntu
 RUN apt update && apt install -y apt-transport-https ca-certificates curl gnupg  python3
 
 # Add google cloud GPG key and Kubernetes repository
-RUN mkdir -p /etc/apt/keyrings/
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /etc/apt/keyrings/google-cloud.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+RUN mkdir -p /etc/apt/keyrings/ && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor > /etc/apt/keyrings/google-cloud.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/google-cloud.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
 
 RUN apt update && apt install -y kubectl


### PR DESCRIPTION
* Also install python3 in the first layer
* merge apt update and installation in one layer
* and use the new `apt` command instead of the old `apt-get`